### PR TITLE
Fixed import errors by directly importing submodules

### DIFF
--- a/comments_extension/forms.py
+++ b/comments_extension/forms.py
@@ -6,6 +6,18 @@ from django.utils.translation import ungettext, ugettext, ugettext_lazy as _
 from django.forms.util import ErrorDict
 from django.utils.crypto import salted_hmac, constant_time_compare
 
+# Try to import django_comments otherwise fallback to the django contrib comments
+try:
+    from django_comments.forms import COMMENT_MAX_LENGTH
+    from django_comments.models import Comment
+except ImportError:
+    try:
+        from django.contrib.comments.forms import COMMENT_MAX_LENGTH
+        from django.contrib.comments.models import Comment
+    except ImportError:
+        raise ImportError('django-comments-extension requires django-contrib-comments to be installed or the deprecated'
+                          ' (as of django 1.6) django.contrib.comments.')
+
 import comments_extension
 
 
@@ -28,7 +40,7 @@ class CommentEditForm(forms.ModelForm):
     user_email = forms.EmailField(label=_("Email address"))
     user_url = forms.URLField(label=_("URL"), required=False)
     comment = forms.CharField(label=_("Comment"), widget=forms.Textarea,
-                                    max_length=comments_extension.django_comments.forms.COMMENT_MAX_LENGTH)
+                                    max_length=COMMENT_MAX_LENGTH)
     
     # Security fields
     timestamp = forms.IntegerField(widget=forms.HiddenInput)
@@ -37,7 +49,7 @@ class CommentEditForm(forms.ModelForm):
                                                        "your comment will be treated as spam."))
     
     class Meta:
-        model = comments_extension.django_comments.models.Comment
+        model = Comment
         fields = ("user_name", "user_email", "user_url", "comment",
                   "timestamp", "security_hash", "honeypot")
 

--- a/comments_extension/templatetags/comments_extension.py
+++ b/comments_extension/templatetags/comments_extension.py
@@ -2,13 +2,23 @@ from __future__ import absolute_import
 from django import template
 from django.template.loader import render_to_string
 
+# Try to import django_comments otherwise fallback to the django contrib comments
+try:
+    from django_comments.templatetags.comments import BaseCommentNode, CommentFormNode
+except ImportError:
+    try:
+        from django.contrib.comments.templatetags.comments import BaseCommentNode, CommentFormNode
+    except ImportError:
+        raise ImportError('django-comments-extension requires django-contrib-comments to be installed or the deprecated'
+                          ' (as of django 1.6) django.contrib.comments.')
+
 import comments_extension
 
 
 register = template.Library()
 
 
-class CommentEditFormNode(comments_extension.django_comments.templatetags.comments.CommentFormNode):
+class CommentEditFormNode(CommentFormNode):
     """
     Insert a form for the comment model into the context.
     """
@@ -20,7 +30,7 @@ class CommentEditFormNode(comments_extension.django_comments.templatetags.commen
             return None
         
 
-class RenderCommentEditFormNode(comments_extension.django_comments.templatetags.comments.CommentFormNode):
+class RenderCommentEditFormNode(CommentFormNode):
     """
     Class method to parse render_comment_edit_form and return a Node
     prefilled with existing data.
@@ -40,7 +50,7 @@ class RenderCommentEditFormNode(comments_extension.django_comments.templatetags.
         # {% render_comment_form for app.models pk %}
         elif len(tokens) == 4:
             return cls(
-                ctype = comments_extension.django_comments.templatetags.comments.BaseCommentNode.lookup_content_type(tokens[2], tokens[0]),
+                ctype = BaseCommentNode.lookup_content_type(tokens[2], tokens[0]),
                 object_pk_expr = parser.compile_filter(tokens[3])
             )
     


### PR DESCRIPTION
A fix for @sjdines's workaround for Django's deprecation of django.contrib.comments.

Doing `import module`, then accessing its submodules like `module.submodule.subsubmodule` only works if the submodules are imported in `module.__init__` or elsewhere in the running Python process, so the code would sporadically work or fail, depending on the context it was run in.

I've replaced the submodule access via attributes with direct imports. This means that the ugly try/except ImportError blocks are repeated in more files, but I haven't been able to find a better way of doing it (e.g. via `importlib.import_module` or `__import__`).

The only alternative is to stick a bunch of additional imports into `coments_extension.__init__`, which will make sure the submodules are accessible via attributes. However, that is both likely to cause circular imports, and grossly violates the principle of least astonishment.